### PR TITLE
Add workflow dispatch inputs to on schedule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ on:
     # every 15 minutes
     - cron: "*/15 * * * *"
   workflow_dispatch:
+    inputs:
+      updateMinutes:
+        description: "Update within minutes"
+        required: false
+        default: 15
+        type: number
 jobs:
   twitter:
     runs-on: ubuntu-latest
@@ -56,7 +62,7 @@ jobs:
           # RSS feed URL
           RSS_URL: "https://hnrss.org/newest"
           TWEET_TEMPLATE: 'New Post: "%title%" %url%'
-          UPDATE_WITHIN_MINUTES: 15 # for workflow_dispatch
+          UPDATE_WITHIN_MINUTES: ${{ inputs.updateMinutes }} # for workflow_dispatch
           TWITTER_APIKEY: ${{ secrets.TWITTER_APIKEY }}
           TWITTER_APIKEY_SECRET: ${{ secrets.TWITTER_APIKEY_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ on:
       updateMinutes:
         description: "Update within minutes"
         required: false
-        default: 15
+        default: 60
         type: number
 jobs:
   twitter:


### PR DESCRIPTION

## Description: 概要
Adds a minute input to the "on schedule" example in the README using [workflow inputs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#providing-inputs).

![image](https://github.com/azu/rss-to-twitter/assets/80087248/e0707b19-fdcb-4cf8-8e96-a2d632e2b26c)


## Changes: 変更内容
<!-- Detail of changes (please add screenshots if applicable) -->
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

<!-- START pr-commits -->
Change README with revised code example which uses workflow inputs

<!-- END pr-commits -->

## Expected Impact: 影響範囲
When you go to the Actions tab and try to run the workflow manually, you can now specify how old a post is in minutes to be able to post as opposed to having it hard coded in.
<!-- e.g. I changed this function, which might be affect that function. -->
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Operating Requirements: 動作要件
<!-- e.g. Environment variables / Dependencies / DB updates -->
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## Additional context: 補足
The name of `UPDATE_WITHIN_MINUTES` isn't clear that it means it's for how old a post can be to be posted to X (formerly Twitter) so users might confuse this field. I don't know any better name so I left it as is.
<!-- e.g. Point or review / Cautions when trying in a local environment -->
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
